### PR TITLE
Fixed: Tests cannot be found on windows, due to usage of `\` instead of `/` in the file path.

### DIFF
--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -222,7 +222,7 @@ function adapter.build_spec(args)
     "--json",
     "--outputFile=" .. results_path,
     "--testNamePattern=" .. testNamePattern,
-    pos.path,
+    string.gsub(pos.path, '\\', '/'),
   })
 
   local cwd = getCwd(pos.path)


### PR DESCRIPTION
Fixes #42

Should now work on all platforms, I assume