### PR TITLE
Adds support for parameterized tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,34 @@ or add a specific keymap to run tests with watch mode:
 vim.api.nvim_set_keymap("n", "<leader>tw", "<cmd>lua require('neotest').run.run({ jestCommand = 'jest --watch ' })<cr>", {})
 ```
 
+### Parameterized tests
+
+If you want to allow to `neotest-jest` to discover parameterized tests you need to enable flag
+`jest_test_discovery` in config setup:
+```lua
+require('neotest').setup({
+  ...,
+  adapters = {
+    require('neotest-jest')({
+      ...,
+      jest_test_discovery = false,
+    }),
+  }
+})
+```
+Its also recommended to disable `neotest` `discovery` option like this:
+```lua
+require("neotest").setup({
+	...,
+	discovery = {
+		enabled = false,
+	},
+})
+```
+because `jest_test_discovery` runs `jest` command on file to determine
+what tests are inside the file. If `discovery` would be enabled then `neotest-jest`
+would spawn a lot of procesees.
+
 ## :gift: Contributing
 
 Please raise a PR if you are interested in adding new functionality or fixing any bugs. When submitting a bug, please include an example spec that can be tested.

--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -133,7 +133,6 @@ function adapter.discover_positions(path)
           object: (identifier) @func_name (#any-of? @func_name "it" "test") 
           property: (property_identifier) @each_name (#eq? @each_name "each")
         )
-        arguments: (arguments (array) @array_parameters)? (template_string)? @template_string_parameters
       )
       arguments: (arguments (string (string_fragment) @test.name) (arrow_function))
     )) @test.definition

--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -137,8 +137,7 @@ function adapter.discover_positions(path)
   local parameterized_tests_positions =
     parameterized_tests.get_parameterized_tests_positions(positions)
 
-  -- put config value here instead of true
-  if true and #parameterized_tests_positions > 0 then
+  if adapter.jest_test_discovery and #parameterized_tests_positions > 0 then
     parameterized_tests.enrich_positions_with_parameterized_tests(
       positions:data().path,
       parameterized_tests_positions
@@ -388,7 +387,7 @@ end
 setmetatable(adapter, {
   ---@param opts neotest.JestOptions
   __call = function(_, opts)
-    if util.is_callable(opts.jestCommand) then
+    if is_callable(opts.jestCommand) then
       getJestCommand = opts.jestCommand
     elseif opts.jestCommand then
       getJestCommand = function()
@@ -423,6 +422,11 @@ setmetatable(adapter, {
         return opts.strategy_config
       end
     end
+
+    if opts.jest_test_discovery then
+      adapter.jest_test_discovery = true
+    end
+
     return adapter
   end,
 })

--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -127,7 +127,7 @@ function adapter.discover_positions(path)
 
   local positions = lib.treesitter.parse_positions(path, query, {
     nested_tests = false,
-    build_position = 'require("neotest-jest.lua.neotest-jest").build_position',
+    build_position = 'require("neotest-jest").build_position',
   })
 
   local parameterized_tests_positions =

--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -66,14 +66,13 @@ function adapter.build_position(file_path, source, captured_nodes)
   local definition = captured_nodes[match_type .. ".definition"]
 
   if captured_nodes["each_name"] then
-    local range = { definition:range() }
     return {
       type = match_type,
       path = file_path,
       name = name,
-      range = range,
+      range = { definition:range() },
       each_test_meta = {
-        jest_test_position = { definition:named_child(1):range() },
+        jest_test_position = { definition:range() },
       },
     }
   end
@@ -143,8 +142,15 @@ function adapter.discover_positions(path)
     build_position = 'require("modified-plugins.neotest-jest.lua.neotest-jest").build_position',
   })
 
-  if true then
-    parameterized_tests.enrich_positions_with_parameterized_tests(positions)
+  local parameterized_tests_positions =
+    parameterized_tests.get_parameterized_tests_positions(positions)
+
+  -- put config value here instead of true
+  if true and #parameterized_tests_positions > 0 then
+    parameterized_tests.enrich_positions_with_parameterized_tests(
+      positions:data().path,
+      parameterized_tests_positions
+    )
   end
 
   return positions

--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -49,7 +49,6 @@ local function rootProjectHasJestDependency()
   return true
 end
 
-
 ---@param path string
 ---@return boolean
 local function hasJestDependency(path)
@@ -244,17 +243,17 @@ end
 local function escapeTestPattern(s)
   return (
     s:gsub("%(", "%\\(")
-    :gsub("%)", "%\\)")
-    :gsub("%]", "%\\]")
-    :gsub("%[", "%\\[")
-    :gsub("%*", "%\\*")
-    :gsub("%+", "%\\+")
-    :gsub("%-", "%\\-")
-    :gsub("%?", "%\\?")
-    :gsub("%$", "%\\$")
-    :gsub("%^", "%\\^")
-    :gsub("%/", "%\\/")
-    :gsub("%'", "%\\'")
+      :gsub("%)", "%\\)")
+      :gsub("%]", "%\\]")
+      :gsub("%[", "%\\[")
+      :gsub("%*", "%\\*")
+      :gsub("%+", "%\\+")
+      :gsub("%-", "%\\-")
+      :gsub("%?", "%\\?")
+      :gsub("%$", "%\\$")
+      :gsub("%^", "%\\^")
+      :gsub("%/", "%\\/")
+      :gsub("%'", "%\\'")
   )
 end
 
@@ -295,10 +294,10 @@ end
 
 local function cleanAnsi(s)
   return s:gsub("\x1b%[%d+;%d+;%d+;%d+;%d+m", "")
-      :gsub("\x1b%[%d+;%d+;%d+;%d+m", "")
-      :gsub("\x1b%[%d+;%d+;%d+m", "")
-      :gsub("\x1b%[%d+;%d+m", "")
-      :gsub("\x1b%[%d+m", "")
+    :gsub("\x1b%[%d+;%d+;%d+;%d+m", "")
+    :gsub("\x1b%[%d+;%d+;%d+m", "")
+    :gsub("\x1b%[%d+;%d+m", "")
+    :gsub("\x1b%[%d+m", "")
 end
 
 local function findErrorPosition(file, errStr)

--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -131,7 +131,6 @@ function adapter.discover_positions(path)
   local positions = lib.treesitter.parse_positions(path, query, {
     nested_tests = false,
     build_position = 'require("neotest-jest").build_position',
-    -- build_position = adapter.build_position,
   })
 
   local parameterized_tests_positions =
@@ -380,7 +379,7 @@ function adapter.results(spec, b, tree)
   return results
 end
 
-local function is_callable(obj)
+local is_callable = function(obj)
   return type(obj) == "function" or (type(obj) == "table" and obj.__call)
 end
 

--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -3,9 +3,8 @@ local async = require("neotest.async")
 local lib = require("neotest.lib")
 local logger = require("neotest.logging")
 local util = require("neotest-jest.util")
-local jest_util = require("modified-plugins.neotest-jest.lua.neotest-jest.jest-util")
-local parameterized_tests =
-  require("modified-plugins.neotest-jest.lua.neotest-jest.parameterized-tests")
+local jest_util = require("neotest-jest.jest-util")
+local parameterized_tests = require("neotest-jest.parameterized-tests")
 
 ---@class neotest.JestOptions
 ---@field jestCommand? string|fun(): string
@@ -128,7 +127,7 @@ function adapter.discover_positions(path)
 
   local positions = lib.treesitter.parse_positions(path, query, {
     nested_tests = false,
-    build_position = 'require("modified-plugins.neotest-jest.lua.neotest-jest").build_position',
+    build_position = 'require("neotest-jest.lua.neotest-jest").build_position',
   })
 
   local parameterized_tests_positions =

--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -65,23 +65,12 @@ function adapter.build_position(file_path, source, captured_nodes)
   local name = vim.treesitter.get_node_text(captured_nodes[match_type .. ".name"], source)
   local definition = captured_nodes[match_type .. ".definition"]
 
-  if captured_nodes["each_name"] then
-    return {
-      type = match_type,
-      path = file_path,
-      name = name,
-      range = { definition:range() },
-      each_test_meta = {
-        jest_test_position = { definition:range() },
-      },
-    }
-  end
-
   return {
     type = match_type,
     path = file_path,
     name = name,
     range = { definition:range() },
+    is_parameterized = captured_nodes["each_property"] and true or false,
   }
 end
 
@@ -130,7 +119,7 @@ function adapter.discover_positions(path)
       function: (call_expression
         function: (member_expression
           object: (identifier) @func_name (#any-of? @func_name "it" "test") 
-          property: (property_identifier) @each_name (#eq? @each_name "each")
+          property: (property_identifier) @each_property (#eq? @each_property "each")
         )
       )
       arguments: (arguments (string (string_fragment) @test.name) (arrow_function))

--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -302,7 +302,7 @@ function adapter.build_spec(args)
     end
   end
 
-  local binary = getJestCommand(pos.path)
+  local binary = args.jestCommand or getJestCommand(pos.path)
   local config = getJestConfig(pos.path) or "jest.config.js"
   local command = vim.split(binary, "%s+")
   if util.path.exists(config) then
@@ -381,14 +381,14 @@ function adapter.results(spec, b, tree)
   return results
 end
 
-local is_callable = function(obj)
+local function is_callable(obj)
   return type(obj) == "function" or (type(obj) == "table" and obj.__call)
 end
 
 setmetatable(adapter, {
   ---@param opts neotest.JestOptions
   __call = function(_, opts)
-    if is_callable(opts.jestCommand) then
+    if util.is_callable(opts.jestCommand) then
       getJestCommand = opts.jestCommand
     elseif opts.jestCommand then
       getJestCommand = function()

--- a/lua/neotest-jest/jest-util.lua
+++ b/lua/neotest-jest/jest-util.lua
@@ -1,0 +1,52 @@
+local util = require("neotest-jest.util")
+
+local M = {}
+
+---@param path string
+---@return string
+function M.getJestCommand(path)
+  local rootPath = util.find_node_modules_ancestor(path)
+  local jestBinary = util.path.join(rootPath, "node_modules", ".bin", "jest")
+
+  if util.path.exists(jestBinary) then
+    return jestBinary
+  end
+
+  return "jest"
+end
+
+local jestConfigPattern = util.root_pattern("jest.config.{js,ts}")
+
+---@param path string
+---@return string|nil
+function M.getJestConfig(path)
+  local rootPath = jestConfigPattern(path)
+
+  if not rootPath then
+    return nil
+  end
+
+  local jestJs = util.path.join(rootPath, "jest.config.js")
+  local jestTs = util.path.join(rootPath, "jest.config.ts")
+
+  if util.path.exists(jestTs) then
+    return jestTs
+  end
+
+  return jestJs
+end
+
+function M.get_test_full_id_from_test_result(testFile, assertionResult)
+  local keyid = testFile
+  local name = assertionResult.title
+
+  for _, value in ipairs(assertionResult.ancestorTitles) do
+    keyid = keyid .. "::" .. value
+  end
+
+  keyid = keyid .. "::" .. name
+
+  return keyid
+end
+
+return M

--- a/lua/neotest-jest/jest-util.lua
+++ b/lua/neotest-jest/jest-util.lua
@@ -8,17 +8,8 @@ end
 
 -- Returns jest binary from `node_modules` if that binary exists and `jest` otherwise.
 ---@param path string
----@param args table - table containing test run arguments
 ---@return string
-function M.getJestCommand(path, args)
-  if args then
-    if M.is_callable(args.jestCommand) then
-      return args.jestCommand()
-    elseif args.jestCommand then
-      return args.jestCommand
-    end
-  end
-
+function M.getJestCommand(path)
   local gitAncestor = util.find_git_ancestor(path)
 
   local function findBinary(p)

--- a/lua/neotest-jest/jest-util.lua
+++ b/lua/neotest-jest/jest-util.lua
@@ -2,6 +2,7 @@ local util = require("neotest-jest.util")
 
 local M = {}
 
+-- Returns jest binary from `node_modules` if that binary exists and `jest` otherwise.
 ---@param path string
 ---@return string
 function M.getJestCommand(path)
@@ -17,6 +18,7 @@ end
 
 local jestConfigPattern = util.root_pattern("jest.config.{js,ts}")
 
+-- Returns jest config file path if it exists.
 ---@param path string
 ---@return string|nil
 function M.getJestConfig(path)
@@ -36,6 +38,10 @@ function M.getJestConfig(path)
   return jestJs
 end
 
+-- Returns neotest test id from jest test result.
+-- @param testFile string
+-- @param assertionResult table
+-- @return string
 function M.get_test_full_id_from_test_result(testFile, assertionResult)
   local keyid = testFile
   local name = assertionResult.title

--- a/lua/neotest-jest/jest-util.lua
+++ b/lua/neotest-jest/jest-util.lua
@@ -2,10 +2,23 @@ local util = require("neotest-jest.util")
 
 local M = {}
 
+function M.is_callable(obj)
+  return type(obj) == "function" or (type(obj) == "table" and obj.__call)
+end
+
 -- Returns jest binary from `node_modules` if that binary exists and `jest` otherwise.
 ---@param path string
+---@param args table - table containing test run arguments
 ---@return string
-function M.getJestCommand(path)
+function M.getJestCommand(path, args)
+  if args then
+    if M.is_callable(args.jestCommand) then
+      return args.jestCommand()
+    elseif args.jestCommand then
+      return args.jestCommand
+    end
+  end
+
   local gitAncestor = util.find_git_ancestor(path)
 
   local function findBinary(p)

--- a/lua/neotest-jest/parameterized-tests.lua
+++ b/lua/neotest-jest/parameterized-tests.lua
@@ -29,12 +29,7 @@ end
 -- @return table - parsed jest test results
 local function run_jest_test_discovery(file_path)
   local binary = jest_util.getJestCommand(file_path)
-  local config = jest_util.getJestConfig(file_path) or "jest.config.js"
   local command = vim.split(binary, "%s+")
-  if util.path.exists(config) then
-    -- only use config if available
-    table.insert(command, "--config=" .. config)
-  end
 
   vim.list_extend(command, {
     "--no-coverage",
@@ -42,6 +37,10 @@ local function run_jest_test_discovery(file_path)
     "--verbose",
     "--json",
     file_path,
+    -- Changing test environment and removing setupFiles to speed up discovery process
+    -- need to test if it can break any tests
+    "--setupFilesAfterEnv=/Users/jaroslaw.glegola/.local/share/nvim/site/pack/packer/start/neotest-jest/lua/neotest-jest/empty.js",
+    "--testEnvironment=node",
     "-t",
     "@______________PLACEHOLDER______________@",
   })

--- a/lua/neotest-jest/parameterized-tests.lua
+++ b/lua/neotest-jest/parameterized-tests.lua
@@ -1,6 +1,6 @@
 local lib = require("neotest.lib")
 local util = require("neotest-jest.util")
-local jest_util = require("modified-plugins.neotest-jest.lua.neotest-jest.jest-util")
+local jest_util = require("neotest-jest.jest-util")
 
 local M = {}
 

--- a/lua/neotest-jest/parameterized-tests.lua
+++ b/lua/neotest-jest/parameterized-tests.lua
@@ -89,22 +89,26 @@ end
 -- and adds new tests (with range=nil) to the parameterized test.
 -- @param file_path string
 -- @param each_tests_positions neotest.Tree[]
-function M.enrich_positions_with_parameterized_tests(file_path, each_tests_positions)
+function M.enrich_positions_with_parameterized_tests(
+  file_path,
+  parsed_parameterized_tests_positions
+)
   local jest_test_discovery_output = run_jest_test_discovery(file_path)
 
   if jest_test_discovery_output == nil then
     return
   end
 
-  for _, value in pairs(each_tests_positions) do
+  for _, value in pairs(parsed_parameterized_tests_positions) do
     local data = value:data()
 
-    local each_test_results = get_tests_ids_at_position(jest_test_discovery_output, data.range)
+    local parameterized_test_results_for_position =
+      get_tests_ids_at_position(jest_test_discovery_output, data.range)
 
-    for _, each_test_result in ipairs(each_test_results) do
+    for _, test_result in ipairs(parameterized_test_results_for_position) do
       local new_data = {
-        id = each_test_result.keyid,
-        name = each_test_result.name,
+        id = test_result.keyid,
+        name = test_result.name,
         path = data.path,
       }
       new_data.range = nil

--- a/lua/neotest-jest/parameterized-tests.lua
+++ b/lua/neotest-jest/parameterized-tests.lua
@@ -4,32 +4,25 @@ local jest_util = require("modified-plugins.neotest-jest.lua.neotest-jest.jest-u
 
 local M = {}
 
-function M.get_tests_ids_at_position(jest_output, position)
-  local test_ids_at_position = {}
-  for _, testResult in pairs(jest_output.testResults) do
-    local testFile = testResult.name
+function M.get_parameterized_tests_positions(positions)
+  local parameterized_tests_positions = {}
 
-    for _, assertionResult in pairs(testResult.assertionResults) do
-      local location, name = assertionResult.location, assertionResult.title
+  for _, value in positions:iter_nodes() do
+    local data = value:data()
 
-      if position[1] == location.line - 1 and position[2] == location.column - 1 then
-        local keyid = jest_util.get_test_full_id_from_test_result(testFile, assertionResult)
-
-        test_ids_at_position[#test_ids_at_position + 1] = { keyid = keyid, name = name }
-      end
+    if data.type == "test" and data.each_test_meta then
+      parameterized_tests_positions[#parameterized_tests_positions + 1] = value
     end
   end
 
-  return test_ids_at_position
+  return parameterized_tests_positions
 end
 
 -- Runs `jest` in `positins` directory skipping all tests. It skips all tests by adding
 -- extra `--testPathPattern` parameter to jest command with placeholder string that should never exist.
-local function run_jest_test_discovery(positions)
-  local positions_root_data = positions:data()
-
-  local binary = jest_util.getJestCommand(positions_root_data.path)
-  local config = jest_util.getJestConfig(positions_root_data.path) or "jest.config.js"
+local function run_jest_test_discovery(file_path)
+  local binary = jest_util.getJestCommand(file_path)
+  local config = jest_util.getJestConfig(file_path) or "jest.config.js"
   local command = vim.split(binary, "%s+")
   if util.path.exists(config) then
     -- only use config if available
@@ -41,7 +34,7 @@ local function run_jest_test_discovery(positions)
     "--testLocationInResults",
     "--verbose",
     "--json",
-    positions_root_data.path,
+    file_path,
     "-t",
     "@______________PLACEHOLDER______________@",
   })
@@ -61,33 +54,48 @@ local function run_jest_test_discovery(positions)
   return vim.json.decode(jest_json_string, { luanil = { object = true } })
 end
 
-function M.enrich_positions_with_parameterized_tests(positions)
-  local jest_test_discovery_output = run_jest_test_discovery(positions)
+local function get_tests_ids_at_position(jest_output, position)
+  local test_ids_at_position = {}
+  for _, testResult in pairs(jest_output.testResults) do
+    local testFile = testResult.name
 
-  if jest_test_discovery_output == nil then
-    return positions
+    for _, assertionResult in pairs(testResult.assertionResults) do
+      local location, name = assertionResult.location, assertionResult.title
+
+      if position[1] <= location.line - 1 and position[3] >= location.line - 1 then
+        local keyid = jest_util.get_test_full_id_from_test_result(testFile, assertionResult)
+
+        test_ids_at_position[#test_ids_at_position + 1] = { keyid = keyid, name = name }
+      end
+    end
   end
 
-  for _, value in positions:iter_nodes() do
+  return test_ids_at_position
+end
+
+function M.enrich_positions_with_parameterized_tests(file_path, each_tests_positions)
+  local jest_test_discovery_output = run_jest_test_discovery(file_path)
+
+  if jest_test_discovery_output == nil then
+    return
+  end
+
+  for _, value in pairs(each_tests_positions) do
     local data = value:data()
 
-    if data.type == "test" and data.each_test_meta then
-      local each_test_results = M.get_tests_ids_at_position(
-        jest_test_discovery_output,
-        data.each_test_meta.jest_test_position
-      )
+    local each_test_results =
+      get_tests_ids_at_position(jest_test_discovery_output, data.each_test_meta.jest_test_position)
 
-      for _, each_test_result in ipairs(each_test_results) do
-        local new_data = {
-          id = each_test_result.keyid,
-          name = each_test_result.name,
-          path = data.path,
-        }
-        new_data.range = nil
+    for _, each_test_result in ipairs(each_test_results) do
+      local new_data = {
+        id = each_test_result.keyid,
+        name = each_test_result.name,
+        path = data.path,
+      }
+      new_data.range = nil
 
-        local new_pos = value:new(new_data, {}, value._key, {}, {})
-        value:add_child(new_data.id, new_pos)
-      end
+      local new_pos = value:new(new_data, {}, value._key, {}, {})
+      value:add_child(new_data.id, new_pos)
     end
   end
 end

--- a/lua/neotest-jest/parameterized-tests.lua
+++ b/lua/neotest-jest/parameterized-tests.lua
@@ -1,0 +1,95 @@
+local lib = require("neotest.lib")
+local util = require("neotest-jest.util")
+local jest_util = require("modified-plugins.neotest-jest.lua.neotest-jest.jest-util")
+
+local M = {}
+
+function M.get_tests_ids_at_position(jest_output, position)
+  local test_ids_at_position = {}
+  for _, testResult in pairs(jest_output.testResults) do
+    local testFile = testResult.name
+
+    for _, assertionResult in pairs(testResult.assertionResults) do
+      local location, name = assertionResult.location, assertionResult.title
+
+      if position[1] == location.line - 1 and position[2] == location.column - 1 then
+        local keyid = jest_util.get_test_full_id_from_test_result(testFile, assertionResult)
+
+        test_ids_at_position[#test_ids_at_position + 1] = { keyid = keyid, name = name }
+      end
+    end
+  end
+
+  return test_ids_at_position
+end
+
+-- Runs `jest` in `positins` directory skipping all tests. It skips all tests by adding
+-- extra `--testPathPattern` parameter to jest command with placeholder string that should never exist.
+local function run_jest_test_discovery(positions)
+  local positions_root_data = positions:data()
+
+  local binary = jest_util.getJestCommand(positions_root_data.path)
+  local config = jest_util.getJestConfig(positions_root_data.path) or "jest.config.js"
+  local command = vim.split(binary, "%s+")
+  if util.path.exists(config) then
+    -- only use config if available
+    table.insert(command, "--config=" .. config)
+  end
+
+  vim.list_extend(command, {
+    "--no-coverage",
+    "--testLocationInResults",
+    "--verbose",
+    "--json",
+    positions_root_data.path,
+    "-t",
+    "@______________PLACEHOLDER______________@",
+  })
+
+  local result = { lib.process.run(command, { stdout = true }) }
+
+  if not result[2] then
+    return nil
+  end
+
+  local jest_json_string = result[2].stdout
+
+  if not jest_json_string or #jest_json_string == 0 then
+    return nil
+  end
+
+  return vim.json.decode(jest_json_string, { luanil = { object = true } })
+end
+
+function M.enrich_positions_with_parameterized_tests(positions)
+  local jest_test_discovery_output = run_jest_test_discovery(positions)
+
+  if jest_test_discovery_output == nil then
+    return positions
+  end
+
+  for _, value in positions:iter_nodes() do
+    local data = value:data()
+
+    if data.type == "test" and data.each_test_meta then
+      local each_test_results = M.get_tests_ids_at_position(
+        jest_test_discovery_output,
+        data.each_test_meta.jest_test_position
+      )
+
+      for _, each_test_result in ipairs(each_test_results) do
+        local new_data = {
+          id = each_test_result.keyid,
+          name = each_test_result.name,
+          path = data.path,
+        }
+        new_data.range = nil
+
+        local new_pos = value:new(new_data, {}, value._key, {}, {})
+        value:add_child(new_data.id, new_pos)
+      end
+    end
+  end
+end
+
+return M

--- a/lua/neotest-jest/parameterized-tests.lua
+++ b/lua/neotest-jest/parameterized-tests.lua
@@ -115,4 +115,32 @@ function M.enrich_positions_with_parameterized_tests(file_path, each_tests_posit
   end
 end
 
+local JEST_PARAMETER_TYPES = {
+  "%%p",
+  "%%s",
+  "%%d",
+  "%%i",
+  "%%f",
+  "%%j",
+  "%%o",
+  "%%#",
+  "%%%%",
+}
+
+-- Replaces all of the jest parameters (named and unnamed) with `.*` regex pattern.
+-- It allows to run all of the parameterized tests in a single run. Idea inpired by Webstorm jest plugin.
+-- @param test_name string - test name with escaped characters
+-- @returns string
+function M.replaceTestParametersWithRegex(test_name)
+  -- replace named parameters: named characters can be single word (like $parameterName)
+  -- or field access words (like $parameterName.fieldName)
+  local result = test_name:gsub("\\$[%a%.]+", ".*")
+
+  for _, parameter in ipairs(JEST_PARAMETER_TYPES) do
+    result = result:gsub(parameter, ".*")
+  end
+
+  return result
+end
+
 return M

--- a/lua/neotest-jest/parameterized-tests.lua
+++ b/lua/neotest-jest/parameterized-tests.lua
@@ -37,10 +37,6 @@ local function run_jest_test_discovery(file_path)
     "--verbose",
     "--json",
     file_path,
-    -- Changing test environment and removing setupFiles to speed up discovery process
-    -- need to test if it can break any tests
-    "--setupFilesAfterEnv=/Users/jaroslaw.glegola/.local/share/nvim/site/pack/packer/start/neotest-jest/lua/neotest-jest/empty.js",
-    "--testEnvironment=node",
     "-t",
     "@______________PLACEHOLDER______________@",
   })

--- a/spec/parameterized.test.ts
+++ b/spec/parameterized.test.ts
@@ -1,0 +1,34 @@
+describe("describe text", () => {
+  it.each(["string"])("test with percent %%", () => {
+    console.log("do test");
+  });
+
+  it.each(["string"])(
+    "test with all of the parameters %p %s %d %i %f %j %o %# %% %p %s %d %i %f %j %o %# %%",
+    async () => {
+      console.log("do test");
+    }
+  );
+
+  it.each(["string"])("test with $namedParameter", () => {
+    console.log("do test");
+  });
+
+  it.each(["string"])(
+    "test with $namedParameter and $anotherNamedParameter",
+    async () => {
+      console.log("do test");
+    }
+  );
+
+  it.each(["string"])("test with $variable.field.otherField", async () => {
+    console.log("do test");
+  });
+
+  it.each(["string"])(
+    "test with $variable.field.otherField and (parenthesis)",
+    async () => {
+      console.log("do test");
+    }
+  );
+});


### PR DESCRIPTION
Hey!
This is a PR that allows to see and run parameterized tests in the summary window.
The main algorithm here is:
1. Run the treesitter queries on the test file.
2. If the file do not have any parameterized tests (it.each, test.each etc.) do not do anything special just return normal test positions
3. If file contains parameterized tests then:
- run `jest` to discover every test in the file
- find all of the test results from `jest` that are on the same position returned by treesitter
- add new positions to the position returned by a treesitter

Closes: https://github.com/haydenmeade/neotest-jest/issues/2

How to run:
Checkout `neotest-jest` to my branch
Demo:

https://user-images.githubusercontent.com/35625949/209713822-dc550b5b-0690-4011-935f-6b4895ab1e17.mov

TODO:
- [x] add support for `test.each` and `it.each`
- [x] ~~add support for `describe.each`~~ (maybe in different PR)
- [x] add a configuration option to enable this behavior
- [x] fix running single parameterized tests (for now if we run e.g. `run_nearest` jest skips them
- [x] fix race condition when running test before it updates its name
- [x] some unit tests