### PR TITLE
Add support for tests declared with normal functions

### DIFF
--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -121,26 +121,47 @@ end
 function adapter.discover_positions(path)
   local query = [[
     ; -- Namespaces --
-    ; Matches: `describe('context')`
+    ; Matches: `describe('context', () => {})`
     ((call_expression
       function: (identifier) @func_name (#eq? @func_name "describe")
-      arguments: (arguments (string (string_fragment) @namespace.name) [(arrow_function) (function)])
+      arguments: (arguments (string (string_fragment) @namespace.name) (arrow_function))
     )) @namespace.definition
-    ; Matches: `describe.only('context')`
+    ; Matches: `describe('context', function() {})`
+    ((call_expression
+      function: (identifier) @func_name (#eq? @func_name "describe")
+      arguments: (arguments (string (string_fragment) @namespace.name) (function))
+    )) @namespace.definition
+    ; Matches: `describe.only('context', () => {})`
     ((call_expression
       function: (member_expression
         object: (identifier) @func_name (#any-of? @func_name "describe")
       )
-      arguments: (arguments (string (string_fragment) @namespace.name) [(arrow_function) (function)])
+      arguments: (arguments (string (string_fragment) @namespace.name) (arrow_function))
     )) @namespace.definition
-    ; Matches: `describe.each(['data'])('context')`
+    ; Matches: `describe.only('context', function() {})`
+    ((call_expression
+      function: (member_expression
+        object: (identifier) @func_name (#any-of? @func_name "describe")
+      )
+      arguments: (arguments (string (string_fragment) @namespace.name) (function))
+    )) @namespace.definition
+    ; Matches: `describe.each(['data'])('context', () => {})`
     ((call_expression
       function: (call_expression
         function: (member_expression
           object: (identifier) @func_name (#any-of? @func_name "describe")
         )
       )
-      arguments: (arguments (string (string_fragment) @namespace.name) [(arrow_function) (function)])
+      arguments: (arguments (string (string_fragment) @namespace.name) (arrow_function))
+    )) @namespace.definition
+    ; Matches: `describe.each(['data'])('context', function() {})`
+    ((call_expression
+      function: (call_expression
+        function: (member_expression
+          object: (identifier) @func_name (#any-of? @func_name "describe")
+        )
+      )
+      arguments: (arguments (string (string_fragment) @namespace.name) (function))
     )) @namespace.definition
 
     ; -- Tests --

--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -124,14 +124,14 @@ function adapter.discover_positions(path)
     ; Matches: `describe('context')`
     ((call_expression
       function: (identifier) @func_name (#eq? @func_name "describe")
-      arguments: (arguments (string (string_fragment) @namespace.name) (arrow_function))
+      arguments: (arguments (string (string_fragment) @namespace.name) [(arrow_function) (function)])
     )) @namespace.definition
     ; Matches: `describe.only('context')`
     ((call_expression
       function: (member_expression
         object: (identifier) @func_name (#any-of? @func_name "describe")
       )
-      arguments: (arguments (string (string_fragment) @namespace.name) (arrow_function))
+      arguments: (arguments (string (string_fragment) @namespace.name) [(arrow_function) (function)])
     )) @namespace.definition
     ; Matches: `describe.each(['data'])('context')`
     ((call_expression
@@ -140,21 +140,21 @@ function adapter.discover_positions(path)
           object: (identifier) @func_name (#any-of? @func_name "describe")
         )
       )
-      arguments: (arguments (string (string_fragment) @namespace.name) (arrow_function))
+      arguments: (arguments (string (string_fragment) @namespace.name) [(arrow_function) (function)])
     )) @namespace.definition
 
     ; -- Tests --
     ; Matches: `test('test') / it('test')`
     ((call_expression
       function: (identifier) @func_name (#any-of? @func_name "it" "test")
-      arguments: (arguments (string (string_fragment) @test.name) (arrow_function))
+      arguments: (arguments (string (string_fragment) @test.name) [(arrow_function) (function)])
     )) @test.definition
     ; Matches: `test.only('test') / it.only('test')`
     ((call_expression
       function: (member_expression
         object: (identifier) @func_name (#any-of? @func_name "test" "it")
       )
-      arguments: (arguments (string (string_fragment) @test.name) (arrow_function))
+      arguments: (arguments (string (string_fragment) @test.name) [(arrow_function) (function)])
     )) @test.definition
     ; Matches: `test.each(['data'])('test') / it.each(['data'])('test')`
     ((call_expression
@@ -163,7 +163,7 @@ function adapter.discover_positions(path)
           object: (identifier) @func_name (#any-of? @func_name "it" "test")
         )
       )
-      arguments: (arguments (string (string_fragment) @test.name) (arrow_function))
+      arguments: (arguments (string (string_fragment) @test.name) [(arrow_function) (function)])
     )) @test.definition
   ]]
 

--- a/spec/array.test.ts
+++ b/spec/array.test.ts
@@ -15,3 +15,21 @@ describe("describe text", () => {
     console.log("do test");
   });
 });
+
+describe("describe text 2", function() {
+  it.each([1, 2, 3])("Array1", function() {
+    console.log("do test");
+  });
+
+  it.each([1, 2, 3])("Array2", async function() {
+    console.log("do test");
+  });
+
+  test.each([1, 2, 3])("Array3", function() {
+    console.log("do test");
+  });
+
+  test.each([1, 2, 3])("Array4", async function() {
+    console.log("do test");
+  });
+});

--- a/spec/basic.test.ts
+++ b/spec/basic.test.ts
@@ -14,4 +14,8 @@ describe("describe text", () => {
   test("4", async () => {
     console.log("do test");
   });
+
+  test("4", async function() {
+    console.log("do test");
+  });
 });

--- a/spec/basic.test.ts
+++ b/spec/basic.test.ts
@@ -14,8 +14,22 @@ describe("describe text", () => {
   test("4", async () => {
     console.log("do test");
   });
+});
+
+describe("describe text 2", function() {
+  it("1", function() {
+    console.log("do test");
+  });
+
+  it("2", async function() {
+    console.log("do test");
+  });
+
+  test("3", function() {
+    console.log("do test");
+  });
 
   test("4", async function() {
     console.log("do test");
   });
-});
+})

--- a/spec/nestedDescribe.test.ts
+++ b/spec/nestedDescribe.test.ts
@@ -1,11 +1,13 @@
 
 describe('outer', () => {
-  describe('inner', () => {
-    it('should do a thing', () => {
-      expect('hello').toEqual('hello');
+  describe('middle', function() {
+    describe('inner', () => {
+      it('should do a thing', () => {
+        expect('hello').toEqual('hello');
+      });
+      it("this has a '", () => {
+        expect('hello').toEqual('hello');
+      });
     });
-    it("this has a '", () => {
-      expect('hello').toEqual('hello');
-    });
-  });
+  })
 });

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -25,6 +25,16 @@ describe("is_test_file", function()
 end)
 
 describe("discover_positions", function()
+  local assert_test_positions_match = function(expected_output, positions)
+    for i, value in ipairs(expected_output) do
+      assert.is.truthy(value)
+      local position = positions[i + 1][1]
+      assert.is.truthy(position)
+      assert.equals(value.name, position.name)
+      assert.equals(value.type, position.type)
+    end
+  end
+
   async.it("provides meaningful names from a basic spec", function()
     local positions = plugin.discover_positions("./spec/basic.test.ts"):to_list()
 
@@ -39,22 +49,42 @@ describe("discover_positions", function()
           type = "namespace",
         },
         {
-          {
-            name = "1",
-            type = "test",
-          },
-          {
-            name = "2",
-            type = "test",
-          },
-          {
-            name = "3",
-            type = "test",
-          },
-          {
-            name = "4",
-            type = "test",
-          },
+          name = "1",
+          type = "test",
+        },
+        {
+          name = "2",
+          type = "test",
+        },
+        {
+          name = "3",
+          type = "test",
+        },
+        {
+          name = "4",
+          type = "test",
+        },
+      },
+      {
+        {
+          name = "describe text 2",
+          type = "namespace",
+        },
+        {
+          name = "1",
+          type = "test",
+        },
+        {
+          name = "2",
+          type = "test",
+        },
+        {
+          name = "3",
+          type = "test",
+        },
+        {
+          name = "4",
+          type = "test",
         },
       },
     }
@@ -63,15 +93,14 @@ describe("discover_positions", function()
     assert.equals(expected_output[1].type, positions[1].type)
     assert.equals(expected_output[2][1].name, positions[2][1].name)
     assert.equals(expected_output[2][1].type, positions[2][1].type)
+    assert.equals(expected_output[3][1].name, positions[3][1].name)
+    assert.equals(expected_output[3][1].type, positions[3][1].type)
 
     assert.equals(5, #positions[2])
-    for i, value in ipairs(expected_output[2][2]) do
-      assert.is.truthy(value)
-      local position = positions[2][i + 1][1]
-      assert.is.truthy(position)
-      assert.equals(value.name, position.name)
-      assert.equals(value.type, position.type)
-    end
+    assert_test_positions_match(expected_output[2][2], positions[2])
+
+    assert.equals(5, #positions[3])
+    assert_test_positions_match(expected_output[3][2], positions[3])
   end)
 
   async.it("provides meaningful names for array driven tests", function()
@@ -92,14 +121,50 @@ describe("discover_positions", function()
             name = "Array1",
             type = "test",
           },
+        },
+        {
           {
             name = "Array2",
             type = "test",
           },
+        },
+        {
           {
             name = "Array3",
             type = "test",
           },
+        },
+        {
+          {
+            name = "Array4",
+            type = "test",
+          },
+        },
+      },
+      {
+        {
+          name = "describe text 2",
+          type = "namespace",
+        },
+        {
+          {
+            name = "Array1",
+            type = "test",
+          },
+        },
+        {
+          {
+            name = "Array2",
+            type = "test",
+          },
+        },
+        {
+          {
+            name = "Array3",
+            type = "test",
+          },
+        },
+        {
           {
             name = "Array4",
             type = "test",
@@ -107,19 +172,16 @@ describe("discover_positions", function()
         },
       },
     }
-
     assert.equals(expected_output[1].name, positions[1].name)
     assert.equals(expected_output[1].type, positions[1].type)
     assert.equals(expected_output[2][1].name, positions[2][1].name)
     assert.equals(expected_output[2][1].type, positions[2][1].type)
+
     assert.equals(5, #positions[2])
-    for i, value in ipairs(expected_output[2][2]) do
-      assert.is.truthy(value)
-      local position = positions[2][i + 1][1]
-      assert.is.truthy(position)
-      assert.equals(value.name, position.name)
-      assert.equals(value.type, position.type)
-    end
+    assert_test_positions_match(expected_output[2][2], positions[2])
+
+    assert.equals(5, #positions[3])
+    assert_test_positions_match(expected_output[3][2], positions[3])
   end)
 end)
 
@@ -171,7 +233,7 @@ describe("build_spec", function()
       return pos.id
     end)
 
-    local spec = plugin.build_spec({ tree = tree:children()[1]:children()[1] })
+    local spec = plugin.build_spec({ tree = tree:children()[1]:children()[1]:children()[1] })
 
     assert.is.truthy(spec)
     local command = spec.command
@@ -179,7 +241,7 @@ describe("build_spec", function()
     assert.contains(command, "jest")
     assert.contains(command, "--json")
     assert.is_not.contains(command, "--config=jest.config.js")
-    assert.contains(command, "--testNamePattern='^outer inner'")
+    assert.contains(command, "--testNamePattern='^outer middle inner'")
     assert.contains(command, "./spec/nestedDescribe.test.ts")
     assert.is.truthy(spec.context.file)
     assert.is.truthy(spec.context.results_path)
@@ -192,14 +254,15 @@ describe("build_spec", function()
       return pos.id
     end)
 
-    local spec = plugin.build_spec({ tree = tree:children()[1]:children()[1]:children()[2] })
+    local spec =
+      plugin.build_spec({ tree = tree:children()[1]:children()[1]:children()[1]:children()[2] })
     assert.is.truthy(spec)
     local command = spec.command
     assert.is.truthy(command)
     assert.contains(command, "jest")
     assert.contains(command, "--json")
     assert.is_not.contains(command, "--config=jest.config.js")
-    assert.contains(command, "--testNamePattern='^outer inner this has a \\'$'")
+    assert.contains(command, "--testNamePattern='^outer middle inner this has a \\'$'")
     assert.contains(command, "./spec/nestedDescribe.test.ts")
     assert.is.truthy(spec.context.file)
     assert.is.truthy(spec.context.results_path)


### PR DESCRIPTION
The current position discovery query only searches for test/contexts that use arrow function for their body, but Jest allows you to use both arrow functions and normal functions. This PR updates the query to support both kinds