### PR TITLE
Add support for file path patterns

### DIFF
--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -278,6 +278,8 @@ function adapter.build_spec(args)
     else
       testNamePattern = testNamePattern .. "'"
     end
+  elseif pos.type == "file" then
+    testNamePattern = pos.name
   end
 
   local binary = getJestCommand(pos.path)
@@ -288,13 +290,15 @@ function adapter.build_spec(args)
     table.insert(command, "--config=" .. config)
   end
 
+  local testPattern = pos.type == "file" and '--testPathPattern=' or '--testNamePattern='
+
   vim.list_extend(command, {
     "--no-coverage",
     "--testLocationInResults",
     "--verbose",
     "--json",
     "--outputFile=" .. results_path,
-    "--testNamePattern=" .. testNamePattern,
+    testPattern .. testNamePattern,
     pos.path,
   })
 


### PR DESCRIPTION
When running against a file `require("neotest").run.run(path)`, the file type is `file` and we should filter the test runner to target only that file (else the pattern will be `--testNamePattern='.*'` == all tests).

This change makes the test runner pattern `--testPathPattern='filename.ts'` when the type is file.