### PR TITLE
fix: detect jest dependency when react-scripts is installed

### DIFF
--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -33,7 +33,7 @@ local function hasJestDependency(path)
 
   if parsedPackageJson["dependencies"] then
     for key, _ in pairs(parsedPackageJson["dependencies"]) do
-      if key == "jest" then
+      if key == "jest" or key == "react-scripts" then
         return true
       end
     end
@@ -41,7 +41,7 @@ local function hasJestDependency(path)
 
   if parsedPackageJson["devDependencies"] then
     for key, _ in pairs(parsedPackageJson["devDependencies"]) do
-      if key == "jest" then
+      if key == "jest" or key == "react-scripts"  then
         return true
       end
     end


### PR DESCRIPTION
related to https://github.com/nvim-neotest/neotest-jest/issues/60#issuecomment-1522414215