### PR TITLE
detect root level package json jest dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,35 @@ or add a specific keymap to run tests with watch mode:
 vim.api.nvim_set_keymap("n", "<leader>tw", "<cmd>lua require('neotest').run.run({ jestCommand = 'jest --watch ' })<cr>", {})
 ```
 
+### Monorepos
+If you have a monorepo setup, you might have to do a little more configuration, especially if
+you have different jest configurations per package.
+
+```lua
+jestConfigFile = function()
+  local file = vim.fn.expand('%:p')
+  if string.find(file, "/packages/") then
+    return string.match(file, "(.-/[^/]+/)src") .. "jest.config.ts"
+  end
+
+  return vim.fn.getcwd() .. "/jest.config.ts"
+end,
+```
+
+Also, if your monorepo set up requires you to learn a specific test file with cwd on the package
+directory (like when you have a lerna setup for example), you might also have to tweak things a
+bit:
+
+```lua
+cwd = function()
+  local file = vim.fn.expand('%:p')
+  if string.find(file, "/packages/") then
+    return string.match(file, "(.-/[^/]+/)src")
+  end
+  return vim.fn.getcwd()
+end
+```
+
 ## :gift: Contributing
 
 Please raise a PR if you are interested in adding new functionality or fixing any bugs. When submitting a bug, please include an example spec that can be tested.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ jestConfigFile = function()
 end,
 ```
 
-Also, if your monorepo set up requires you to learn a specific test file with cwd on the package
+Also, if your monorepo set up requires you to run a specific test file with cwd on the package
 directory (like when you have a lerna setup for example), you might also have to tweak things a
 bit:
 

--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -14,6 +14,40 @@ local util = require("neotest-jest.util")
 ---@type neotest.Adapter
 local adapter = { name = "neotest-jest" }
 
+local rootPackageJson = vim.fn.getcwd() .. "/package.json"
+
+---@return boolean
+local function rootProjectHasJestDependency()
+  local path = rootPackageJson
+
+  local success, packageJsonContent = pcall(lib.files.read, path)
+  if not success then
+    print("cannot read package.json")
+    return false
+  end
+
+  local parsedPackageJson = vim.json.decode(packageJsonContent)
+
+  if parsedPackageJson["dependencies"] then
+    for key, _ in pairs(parsedPackageJson["dependencies"]) do
+      if key == "jest" then
+        return true
+      end
+    end
+  end
+
+  if parsedPackageJson["devDependencies"] then
+    for key, _ in pairs(parsedPackageJson["devDependencies"]) do
+      if key == "jest" then
+        return true
+      end
+    end
+  end
+
+  return true
+end
+
+
 ---@param path string
 ---@return boolean
 local function hasJestDependency(path)
@@ -47,7 +81,7 @@ local function hasJestDependency(path)
     end
   end
 
-  return false
+  return rootProjectHasJestDependency()
 end
 
 adapter.root = function(path)
@@ -189,17 +223,17 @@ end
 local function escapeTestPattern(s)
   return (
     s:gsub("%(", "%\\(")
-      :gsub("%)", "%\\)")
-      :gsub("%]", "%\\]")
-      :gsub("%[", "%\\[")
-      :gsub("%*", "%\\*")
-      :gsub("%+", "%\\+")
-      :gsub("%-", "%\\-")
-      :gsub("%?", "%\\?")
-      :gsub("%$", "%\\$")
-      :gsub("%^", "%\\^")
-      :gsub("%/", "%\\/")
-      :gsub("%'", "%\\'")
+    :gsub("%)", "%\\)")
+    :gsub("%]", "%\\]")
+    :gsub("%[", "%\\[")
+    :gsub("%*", "%\\*")
+    :gsub("%+", "%\\+")
+    :gsub("%-", "%\\-")
+    :gsub("%?", "%\\?")
+    :gsub("%$", "%\\$")
+    :gsub("%^", "%\\^")
+    :gsub("%/", "%\\/")
+    :gsub("%'", "%\\'")
   )
 end
 
@@ -240,10 +274,10 @@ end
 
 local function cleanAnsi(s)
   return s:gsub("\x1b%[%d+;%d+;%d+;%d+;%d+m", "")
-    :gsub("\x1b%[%d+;%d+;%d+;%d+m", "")
-    :gsub("\x1b%[%d+;%d+;%d+m", "")
-    :gsub("\x1b%[%d+;%d+m", "")
-    :gsub("\x1b%[%d+m", "")
+      :gsub("\x1b%[%d+;%d+;%d+;%d+m", "")
+      :gsub("\x1b%[%d+;%d+;%d+m", "")
+      :gsub("\x1b%[%d+;%d+m", "")
+      :gsub("\x1b%[%d+m", "")
 end
 
 local function findErrorPosition(file, errStr)


### PR DESCRIPTION
This PR adds back support for monorepos by detecting a jest dependency at the root level of the repo.
Added some docs for some example configuration to handle edge cases like different jest configs per package or if your monorepo test runner does not support running an individual test file

I'm not sure this is the right solution, especially since I did this to work for me, but thoughts are welcome