### PR TITLE
Use args.jestCommand if exists as an override

### DIFF
--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -370,7 +370,7 @@ function adapter.build_spec(args)
     end
   end
 
-  local binary = getJestCommand(pos.path)
+  local binary = args.jestCommand or getJestCommand(pos.path)
   local config = getJestConfig(pos.path) or "jest.config.js"
   local command = vim.split(binary, "%s+")
   if util.path.exists(config) then

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -143,6 +143,26 @@ describe("build_spec", function()
     assert.is.truthy(spec.context.results_path)
   end)
 
+  async.it("builds command for file test with jestCommand arg", function()
+    local positions = plugin.discover_positions("./spec/basic.test.ts"):to_list()
+    local tree = Tree.from_list(positions, function(pos)
+      return pos.id
+    end)
+    local spec = plugin.build_spec({ tree = tree, jestCommand = 'jest --watch ' })
+
+    assert.is.truthy(spec)
+    local command = spec.command
+    assert.is.truthy(command)
+    assert.contains(command, "jest")
+    assert.contains(command, "--watch")
+    assert.contains(command, "--json")
+    assert.is_not.contains(command, "--config=jest.config.js")
+    assert.contains(command, "--testNamePattern='.*'")
+    assert.contains(command, "./spec/basic.test.ts")
+    assert.is.truthy(spec.context.file)
+    assert.is.truthy(spec.context.results_path)
+  end)
+
   async.it("builds command for namespace", function()
     local positions = plugin.discover_positions("./spec/basic.test.ts"):to_list()
 


### PR DESCRIPTION
Got a quick fix here for `watch` mode. Should fix #43 

README states that we should be able to set the `jestCommand` like so: `lua require('neotest').run.run({ jestCommand = 'jest --watch ' })`

That arg is not being referenced anywhere, and should act as an override to any more global defined `jestCommand`.

The change here is to just use the `arg.jestCommand` if it exists.

This got watch mode working for me