### PR TITLE
Support new test file name suffixes: unit, regression and integration

### DIFF
--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -100,7 +100,7 @@ function adapter.is_test_file(file_path)
     is_test_file = true
   end
 
-  for _, x in ipairs({ "spec", "test" }) do
+  for _, x in ipairs({ "spec", "test", "unit" }) do
     for _, ext in ipairs({ "js", "jsx", "coffee", "ts", "tsx" }) do
       if string.match(file_path, "%." .. x .. "%." .. ext .. "$") then
         is_test_file = true

--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -100,7 +100,7 @@ function adapter.is_test_file(file_path)
     is_test_file = true
   end
 
-  for _, x in ipairs({ "spec", "test", "unit" }) do
+  for _, x in ipairs({ "spec", "test", "unit", "regression", "integration" }) do
     for _, ext in ipairs({ "js", "jsx", "coffee", "ts", "tsx" }) do
       if string.match(file_path, "%." .. x .. "%." .. ext .. "$") then
         is_test_file = true


### PR DESCRIPTION
Some codebases use different suffixes to distinguish between types of tests.

Examples:
- `test.integration.ts`
- `test.regression.ts`
- `test.unit.ts`