### PR TITLE
fix: don't load adapter if root project does not have jest dependency

### DIFF
--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -44,7 +44,7 @@ local function rootProjectHasJestDependency()
     end
   end
 
-  return true
+  return false
 end
 
 


### PR DESCRIPTION
default behaviour if no jest dependency is found is to use jest adapter
closes #70