### PR TITLE
Enhance jest detection

### DIFF
--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -81,6 +81,14 @@ local function hasJestDependency(path)
     end
   end
 
+  if parsedPackageJson["scripts"] then
+    for _, value in pairs(parsedPackageJson["scripts"]) do
+      if value == "jest" then
+        return true
+      end
+    end
+  end
+
   return rootProjectHasJestDependency()
 end
 


### PR DESCRIPTION
adds another check to see if jest should be used to test.
For some repositories the jest dependency is not in the nearest package.json (relative to the test file) nor in the root of the project. In this case the former approach would return `No tests found`

But imo if we have the package.json test script set to jest it indicates that we want to use jest for testing.

This might also solve the issue #74 
