### PR TITLE
fix: escape test file path

### DIFF
--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -409,7 +409,7 @@ function adapter.build_spec(args)
     "--json",
     "--outputFile=" .. results_path,
     "--testNamePattern=" .. testNamePattern,
-    pos.path,
+    escapeTestPattern(pos.path),
   })
 
   local cwd = getCwd(pos.path)


### PR DESCRIPTION
In case special symbols are present in file path, jest won't find the actual file, thus failing the test run.

Example:
`libs/store/entity/src/lib/+state/entity.reducer.spec.ts`

Encountered this when trying to test ngrx-store spec files generated by @ngrx/schematics:store.