### PR TITLE
fix windows support

### DIFF
--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -313,14 +313,6 @@ local function parsed_json_to_results(data, output_file, consoleOut)
 
   for _, testResult in pairs(data.testResults) do
     local testFn = testResult.name
-    if vim.loop.os_uname().sysname:find("Windows") == 1 then
-      -- Transforms C:\\path\file into c:\\path\file to match original testId
-      if string.match(testFn, "^%a:\\") then
-        local drive = testFn:sub(1, 1)
-        local restOfPath = testFn:sub(2)
-        testFn = drive:lower() .. restOfPath
-      end
-    end
     for _, assertionResult in pairs(testResult.assertionResults) do
       local status, name = assertionResult.status, assertionResult.title
 

--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -313,7 +313,14 @@ local function parsed_json_to_results(data, output_file, consoleOut)
 
   for _, testResult in pairs(data.testResults) do
     local testFn = testResult.name
-
+    if vim.loop.os_uname().sysname:find('Windows') == 1 then
+      -- Transforms C:\\path\file into c:\\path\file to match original testId
+      if string.match(testFn, "^%a:\\") then
+        local drive = testFn:sub(1,1)
+        local restOfPath = testFn:sub(2)
+        testFn = drive:lower() .. restOfPath
+      end
+    end
     for _, assertionResult in pairs(testResult.assertionResults) do
       local status, name = assertionResult.status, assertionResult.title
 
@@ -409,7 +416,7 @@ function adapter.build_spec(args)
     "--json",
     "--outputFile=" .. results_path,
     "--testNamePattern=" .. testNamePattern,
-    pos.path,
+    vim.fs.normalize(pos.path),
   })
 
   local cwd = getCwd(pos.path)

--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -313,10 +313,10 @@ local function parsed_json_to_results(data, output_file, consoleOut)
 
   for _, testResult in pairs(data.testResults) do
     local testFn = testResult.name
-    if vim.loop.os_uname().sysname:find('Windows') == 1 then
+    if vim.loop.os_uname().sysname:find("Windows") == 1 then
       -- Transforms C:\\path\file into c:\\path\file to match original testId
       if string.match(testFn, "^%a:\\") then
-        local drive = testFn:sub(1,1)
+        local drive = testFn:sub(1, 1)
         local restOfPath = testFn:sub(2)
         testFn = drive:lower() .. restOfPath
       end


### PR DESCRIPTION
This plugin in windows has 2 issues:

1) Jest only accepts paths with forward slash but the plugin sends it backwards as reported in #42

~~2) After solving the first issue i noticed that neotest doesn't update the sign for each test making every test appear with an X even if the test passed. This is caused due to the test having an id like `c:\\path\file::test_name` and the Jest output reports the path like `C:\\path\file::test_name` (notice the capital drive)~~  It seems that neotest now respects the case of the test id so this is no longer an issue.

This PR attemps to solve both issues.

First issue was solved using ` vim.fs.normalize` as recommended in https://github.com/nvim-neotest/neotest-jest/pull/44#issuecomment-1420417168.

~~Second issue was solved adding a windows only validation that changes the case of the drive.~~

Tested in windows everything works as expected. Should not cause any issue in other platforms.

Fixes #42 
Supersedes #44 
