### PR TITLE
Consider .e2e-spec. prefix as a test file

### DIFF
--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -104,7 +104,7 @@ function adapter.is_test_file(file_path)
     is_test_file = true
   end
 
-  for _, x in ipairs({ "spec", "test", "unit", "regression", "integration" }) do
+  for _, x in ipairs({ "spec", "e2e-spec", "test", "unit", "regression", "integration" }) do
     for _, ext in ipairs({ "js", "jsx", "coffee", "ts", "tsx" }) do
       if string.match(file_path, "%." .. x .. "%." .. ext .. "$") then
         is_test_file = true

--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -104,7 +104,7 @@ function adapter.is_test_file(file_path)
     is_test_file = true
   end
 
-  for _, x in ipairs({ "spec", "e2e-spec", "test", "unit", "regression", "integration" }) do
+  for _, x in ipairs({ "spec", "e2e%-spec", "test", "unit", "regression", "integration" }) do
     for _, ext in ipairs({ "js", "jsx", "coffee", "ts", "tsx" }) do
       if string.match(file_path, "%." .. x .. "%." .. ext .. "$") then
         is_test_file = true


### PR DESCRIPTION
Added "e2e-spec" prefix to the list of valid tests prefixes.