### PR TITLE
Update README `watch` mode instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ require('neotest').setup({
   ...,
   adapters = {
     require('neotest-jest')({
-      jestCommand = "jest --watch ",
+      jestCommand = require('neotest-jest.jest-util').getJestCommand(vim.fn.expand '%:p:h') .. ' --watch',
     }),
   }
 })


### PR DESCRIPTION
This new command uses the exact same command the plugin uses by default to find the jest binary. It ensures it'll always work the same.

Ideally, a new `watch = true` could be used, making it transparent to the user. If you like this idea I can work on the implementation.