### PR TITLE
fix: fix javascript treesitter queries

### DIFF
--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -162,7 +162,7 @@ function adapter.discover_positions(path)
     ; Matches: `describe('context', function() {})`
     ((call_expression
       function: (identifier) @func_name (#eq? @func_name "describe")
-      arguments: (arguments (string (string_fragment) @namespace.name) (function))
+      arguments: (arguments (string (string_fragment) @namespace.name) (function_expression))
     )) @namespace.definition
     ; Matches: `describe.only('context', () => {})`
     ((call_expression
@@ -176,7 +176,7 @@ function adapter.discover_positions(path)
       function: (member_expression
         object: (identifier) @func_name (#any-of? @func_name "describe")
       )
-      arguments: (arguments (string (string_fragment) @namespace.name) (function))
+      arguments: (arguments (string (string_fragment) @namespace.name) (function_expression))
     )) @namespace.definition
     ; Matches: `describe.each(['data'])('context', () => {})`
     ((call_expression
@@ -194,21 +194,21 @@ function adapter.discover_positions(path)
           object: (identifier) @func_name (#any-of? @func_name "describe")
         )
       )
-      arguments: (arguments (string (string_fragment) @namespace.name) (function))
+      arguments: (arguments (string (string_fragment) @namespace.name) (function_expression))
     )) @namespace.definition
 
     ; -- Tests --
     ; Matches: `test('test') / it('test')`
     ((call_expression
       function: (identifier) @func_name (#any-of? @func_name "it" "test")
-      arguments: (arguments (string (string_fragment) @test.name) [(arrow_function) (function)])
+      arguments: (arguments (string (string_fragment) @test.name) [(arrow_function) (function_expression)])
     )) @test.definition
     ; Matches: `test.only('test') / it.only('test')`
     ((call_expression
       function: (member_expression
         object: (identifier) @func_name (#any-of? @func_name "test" "it")
       )
-      arguments: (arguments (string (string_fragment) @test.name) [(arrow_function) (function)])
+      arguments: (arguments (string (string_fragment) @test.name) [(arrow_function) (function_expression)])
     )) @test.definition
     ; Matches: `test.each(['data'])('test') / it.each(['data'])('test')`
     ((call_expression
@@ -218,7 +218,7 @@ function adapter.discover_positions(path)
           property: (property_identifier) @each_property (#eq? @each_property "each")
         )
       )
-      arguments: (arguments (string (string_fragment) @test.name) [(arrow_function) (function)])
+      arguments: (arguments (string (string_fragment) @test.name) [(arrow_function) (function_expression)])
     )) @test.definition
   ]]
 


### PR DESCRIPTION
BREAKING_CHANGE: switch to the new (function_expression) pattern that replaces the previous (function). This will be a breaking change for anyone on v0.9.1 or earlier of treesitter

This addresses the failures in test discovery as reported in https://github.com/nvim-neotest/neotest-jest/issues/99