### PR TITLE
Fix monorepo configuration in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,7 @@ If you have a monorepo setup, you might have to do a little more configuration, 
 you have different jest configurations per package.
 
 ```lua
-jestConfigFile = function()
-  local file = vim.fn.expand('%:p')
+jestConfigFile = function(file)
   if string.find(file, "/packages/") then
     return string.match(file, "(.-/[^/]+/)src") .. "jest.config.ts"
   end
@@ -114,8 +113,7 @@ directory (like when you have a lerna setup for example), you might also have to
 bit:
 
 ```lua
-cwd = function()
-  local file = vim.fn.expand('%:p')
+cwd = function(file)
   if string.find(file, "/packages/") then
     return string.match(file, "(.-/[^/]+/)src")
   end


### PR DESCRIPTION
Monorepo configuration in Readme is not working when I tried to run the tests from the Neotest summary window. This is because `vim.fn.expand('%:p')` returns Neotest's summary window path instead of the test file path when I try to invoke `run` from the summary window. 

The changes in the PR pick up the test file path from the `neotest.RunArgs`