### PR TITLE
Fix styling, update workflow

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -32,10 +32,10 @@ jobs:
           - os: ubuntu-20.04
             url: https://github.com/neovim/neovim/releases/download/nightly/nvim-linux64.tar.gz
           - os: ubuntu-20.04
-            url: https://github.com/neovim/neovim/releases/download/v0.7.0/nvim-linux64.tar.gz
+            url: https://github.com/neovim/neovim/releases/download/v0.9.0/nvim-linux64.tar.gz
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: date +%F > todays-date
       - name: Restore cache for today's nightly.
         uses: actions/cache@v2

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 [![build](https://github.com/haydenmeade/neotest-jest/actions/workflows/workflow.yaml/badge.svg)](https://github.com/haydenmeade/neotest-jest/actions/workflows/workflow.yaml)
 
-This plugin provides a jest adapter for the [Neotest](https://github.com/rcarriga/neotest) framework.
+This plugin provides a [jest](https://github.com/jestjs/jest) adapter for the [Neotest](https://github.com/rcarriga/neotest) framework.
+Requires at least Neotest version 4.0.0 which in turn requires at least neovim version 0.9.0.
+
 **It is currently a work in progress**.
 
 ## Installation

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -241,7 +241,7 @@ describe("build_spec", function()
     local tree = Tree.from_list(positions, function(pos)
       return pos.id
     end)
-    local spec = plugin.build_spec({ tree = tree, jestCommand = 'jest --watch ' })
+    local spec = plugin.build_spec({ tree = tree, jestCommand = "jest --watch " })
 
     assert.is.truthy(spec)
     local command = spec.command


### PR DESCRIPTION
* Updated styling so stylua passes.
* I've changed the workflow to use neovim 0.9.0 instead of 0.7.0 due to the neotest requiring at least neovim 0.9.0 after version 4. See the explanation [here](https://github.com/adrigzr/neotest-mocha/pull/13#issuecomment-1917015899) for more information.