### PR TITLE
Add better detection for jest

### DIFF
--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -82,6 +82,20 @@ local function hasJestDependency(path)
     end
   end
 
+  if parsedPackageJson["scripts"] then
+    for _, value in pairs(parsedPackageJson["scripts"]) do
+      if string.find(value, "jest") then
+        return true
+      elseif value == "react-scripts test" then
+        return true
+      end
+    end
+  end
+
+  if parsedPackageJson["jest"] then
+    return true
+  end
+
   return rootProjectHasJestDependency()
 end
 


### PR DESCRIPTION
This fixes some issues:
- Checks if a script has the command `jest` in it
- Checks if project uses CRA test (which has jest as dependency), fixes issue #74 
- Checks if project uses `jest` configuration in `package.json` ([comment](https://github.com/nvim-neotest/neotest-jest/pull/80#issuecomment-1866430246))