### PR TITLE
fix: escape test file path

### DIFF
--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -409,7 +409,7 @@ function adapter.build_spec(args)
     "--outputFile=" .. results_path,
     "--testNamePattern=" .. testNamePattern,
     "--forceExit",
-    vim.fs.normalize(pos.path),
+    escapeTestPattern(vim.fs.normalize(pos.path)),
   })
 
   local cwd = getCwd(pos.path)


### PR DESCRIPTION
Updates the file path parsing to escape special characters. This fixes #108