### PR TITLE
Configurable test patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,12 @@ require('neotest').setup({
   adapters = {
     require('neotest-jest')({
       ...,
-      jest_test_discovery = false,
+      jest_test_discovery = true,
     }),
   }
 })
 ```
-Its also recommended to disable `neotest` `discovery` option like this:
+It's also recommended to disable `neotest` `discovery` option like this:
 ```lua
 require("neotest").setup({
 	...,
@@ -122,6 +122,37 @@ cwd = function(file)
   return vim.fn.getcwd()
 end
 ```
+
+### Custom test extensions
+
+If the default test extensions don't match your test patterns, you can provide
+your own:
+
+```lua
+require('neotest').setup({
+    ...,
+    adapters = {
+      require('neotest-jest')({
+        ...,
+        extension_test_file_match = require('neotest-jest.util').create_test_file_extensions_matcher({ "perf", "spec" }, { "ts", "tsx" })
+      }),
+    }
+})
+```
+
+The call to `create_test_file_extensions_matcher` will return a function that will match
+`".perf.ts"`, `".perf.tsx"`, `".spec.ts"`, and `".spec.tsx"` test patterns.
+
+Note that the default test extensions won't be used for matching anymore. If you
+want to extend the defaults, you can retrieve them.
+
+```lua
+local intermediate_extensions, extensions =
+require('neotest-jest.util').default_test_extensions()
+```
+
+Here, `intermediate_extensions` are the extensions like `perf` and `spec` and
+`extensions` is `ts` and `tsx` in the example above.
 
 ## :gift: Contributing
 

--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -101,9 +101,8 @@ end
 local getJestCommand = jest_util.getJestCommand
 local getJestConfig = jest_util.getJestConfig
 local intermediate_extensions, extensions = util.default_test_extensions()
-local extension_test_file_match = util.create_test_file_extensions_matcher(
-  intermediate_extensions, extensions
-)
+local extension_test_file_match =
+  util.create_test_file_extensions_matcher(intermediate_extensions, extensions)
 
 ---@param file_path? string
 ---@return boolean

--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -100,9 +100,9 @@ end
 
 local getJestCommand = jest_util.getJestCommand
 local getJestConfig = jest_util.getJestConfig
+local intermediate_extensions, extensions = util.default_test_extensions()
 local extension_test_file_match = util.create_test_file_extensions_matcher(
-  { "spec", "e2e%-spec", "test", "unit", "regression", "integration" },
-  { "js", "jsx", "coffee", "ts", "tsx" }
+  intermediate_extensions, extensions
 )
 
 ---@param file_path? string

--- a/lua/neotest-jest/util.lua
+++ b/lua/neotest-jest/util.lua
@@ -264,7 +264,7 @@ function M.create_test_file_extensions_matcher(intermediate_extensions, end_exte
 
     for _, iext in ipairs(intermediate_extensions) do
       for _, eext in ipairs(end_extensions) do
-        if string.match(file_path, iext .. "%." .. eext .. "$") then
+        if string.match(file_path, "%." .. iext .. "%." .. eext .. "$") then
           return true
         end
       end

--- a/lua/neotest-jest/util.lua
+++ b/lua/neotest-jest/util.lua
@@ -177,6 +177,7 @@ function M.find_node_modules_ancestor(startpath)
     end
   end)
 end
+
 function M.find_package_json_ancestor(startpath)
   return M.search_ancestors(startpath, function(path)
     if M.path.is_file(M.path.join(path, "package.json")) then
@@ -184,6 +185,7 @@ function M.find_package_json_ancestor(startpath)
     end
   end)
 end
+
 function M.find_git_ancestor(startpath)
   return M.search_ancestors(startpath, function(path)
     -- .git is a file when the project is a git worktree
@@ -237,6 +239,18 @@ function M.stream(file_path)
   async.run(stop)
 
   return queue.get, exit_future.set
+end
+
+---@return string[]
+---@return string[]
+function M.default_test_extensions()
+  return { "spec", "e2e%-spec", "test", "unit", "regression", "integration" }, {
+    "js",
+    "jsx",
+    "coffee",
+    "ts",
+    "tsx",
+  }
 end
 
 ---@param intermediate_extensions string[]

--- a/lua/neotest-jest/util.lua
+++ b/lua/neotest-jest/util.lua
@@ -239,4 +239,25 @@ function M.stream(file_path)
   return queue.get, exit_future.set
 end
 
+---@param intermediate_extensions string[]
+---@param end_extensions string[]
+---@return fun(file_path: string): boolean
+function M.create_test_file_extensions_matcher(intermediate_extensions, end_extensions)
+  return function(file_path)
+    if file_path == nil then
+      return false
+    end
+
+    for _, iext in ipairs(intermediate_extensions) do
+      for _, eext in ipairs(end_extensions) do
+        if string.match(file_path, iext .. "%." .. eext .. "$") then
+          return true
+        end
+      end
+    end
+
+    return false
+  end
+end
+
 return M

--- a/tests/init_options_spec.lua
+++ b/tests/init_options_spec.lua
@@ -34,7 +34,7 @@ describe("build_spec with override", function()
     assert.contains(command, "--json")
     assert.contains(command, "--config=" .. config_override())
     assert.contains(command, "--testNamePattern='.*'")
-    assert.contains(command, "./spec/basic.test.ts")
+    assert.contains(command, ".\\/spec\\/basic.test.ts")
     assert.is.truthy(spec.context.file)
     assert.is.truthy(spec.context.results_path)
     assert.is.same(

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -28,7 +28,10 @@ describe("is_test_file", function()
   it("gets default test extensions", function()
     local intermediate_extensions, extensions = util.default_test_extensions()
 
-    assert.same(intermediate_extensions, { "spec", "e2e%-spec", "test", "unit", "regression", "integration" })
+    assert.same(
+      intermediate_extensions,
+      { "spec", "e2e%-spec", "test", "unit", "regression", "integration" }
+    )
     assert.same(extensions, { "js", "jsx", "coffee", "ts", "tsx" })
   end)
 
@@ -45,10 +48,8 @@ describe("is_test_file", function()
   async.it("matches test files with configurable test patterns", function()
     local intermediate_extensions = { "spec", "lollipop" }
     local extensions = { "js", "ts" }
-    local is_test_file = util.create_test_file_extensions_matcher(
-      intermediate_extensions,
-      extensions
-    )
+    local is_test_file =
+      util.create_test_file_extensions_matcher(intermediate_extensions, extensions)
 
     for _, extension1 in ipairs(intermediate_extensions) do
       for _, extension2 in ipairs(extensions) do

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -36,13 +36,44 @@ describe("is_test_file", function()
   end)
 
   async.it("matches test files with default test patterns", function()
+    stub(require("neotest.lib").files, "match_root_pattern", function()
+        return function(path)
+            return path
+        end
+    end)
+
+    stub(require("neotest.lib").files, "read", function()
+        return [[
+{
+  "name": "spec",
+  "version": "1.0.0",
+  "description": "neotest-jest spec",
+  "main": "index.js",
+  "license": "MIT",
+  "dependencies": {
+    "jest": "^28.1.2",
+    "ts-node": "^10.8.2",
+    "typescript": "^4.7.4"
+  },
+  "devDependencies": {
+    "@types/jest": "^28.1.4",
+    "@types/node": "^18.0.3"
+  }
+}]]
+    end)
+
     local intermediate_extensions, extensions = util.default_test_extensions()
 
     for _, extension1 in ipairs(intermediate_extensions) do
       for _, extension2 in ipairs(extensions) do
-        assert.True(plugin.is_test_file("./spec/basic." .. extension1 .. "." .. extension2))
+        local stripped_path, _ = ("./spec/basic." .. extension1 .. "." .. extension2):gsub("%%%-", "%-")
+
+        assert.True(plugin.is_test_file(stripped_path))
       end
     end
+
+    require("neotest.lib").files.match_root_pattern:revert()
+    require("neotest.lib").files.read:revert()
   end)
 
   async.it("matches test files with configurable test patterns", function()

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -37,13 +37,13 @@ describe("is_test_file", function()
 
   async.it("matches test files with default test patterns", function()
     stub(require("neotest.lib").files, "match_root_pattern", function()
-        return function(path)
-            return path
-        end
+      return function(path)
+        return path
+      end
     end)
 
     stub(require("neotest.lib").files, "read", function()
-        return [[
+      return [[
 {
   "name": "spec",
   "version": "1.0.0",
@@ -66,7 +66,10 @@ describe("is_test_file", function()
 
     for _, extension1 in ipairs(intermediate_extensions) do
       for _, extension2 in ipairs(extensions) do
-        local stripped_path, _ = ("./spec/basic." .. extension1 .. "." .. extension2):gsub("%%%-", "%-")
+        local stripped_path, _ = ("./spec/basic." .. extension1 .. "." .. extension2):gsub(
+          "%%%-",
+          "%-"
+        )
 
         assert.True(plugin.is_test_file(stripped_path))
       end

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -43,7 +43,7 @@ describe("is_test_file", function()
   end)
 
   async.it("matches test files with configurable test patterns", function()
-    local intermediate_extensions = { "spec", "test", "lollipop" }
+    local intermediate_extensions = { "spec", "lollipop" }
     local extensions = { "js", "ts" }
     local is_test_file = util.create_test_file_extensions_matcher(
       intermediate_extensions,
@@ -57,7 +57,7 @@ describe("is_test_file", function()
     end
 
     -- Does not match anymore with custom extensions
-    assert.False(is_test_file("./spec/sample.integration.ts"))
+    assert.False(is_test_file("./spec/basic.test.ts"))
   end)
 end)
 


### PR DESCRIPTION
This is basically the same PR as the one I made here adrigzr/neotest-mocha#2 which allows for user-configurable test patterns instead of having to gradually accommodate more and more patterns.

### Other changes

* Fixed a typo(?) in the README about enabling `jest_test_discovery`.
* Updated/fixed tests as in #106.