### PR TITLE
fix(windows): path reducing for jest pattern

### DIFF
--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -372,6 +372,13 @@ local function parsed_json_to_results(data, output_file, consoleOut)
   return tests
 end
 
+local function reducePattern(cwd, path)
+  local normalized_cwd = vim.fn.resolve(vim.fs.normalize(cwd) .. '/')
+  local normalized_path = vim.fs.normalize(path)
+
+  return vim.fn.substitute(normalized_path, normalized_cwd, '', 'g');
+end
+
 ---@param args neotest.RunArgs
 ---@return neotest.RunSpec | nil
 function adapter.build_spec(args)
@@ -409,6 +416,8 @@ function adapter.build_spec(args)
     table.insert(command, "--config=" .. config)
   end
 
+  local cwd = getCwd(pos.path)
+
   vim.list_extend(command, {
     "--no-coverage",
     "--testLocationInResults",
@@ -417,10 +426,8 @@ function adapter.build_spec(args)
     "--outputFile=" .. results_path,
     "--testNamePattern=" .. testNamePattern,
     "--forceExit",
-    escapeTestPattern(vim.fs.normalize(pos.path)),
+    escapeTestPattern(reducePattern(cwd, pos.path)),
   })
-
-  local cwd = getCwd(pos.path)
 
   -- creating empty file for streaming results
   lib.files.write(results_path, "")


### PR DESCRIPTION
Fix for https://github.com/nvim-neotest/neotest-jest/issues/113

There are few issues with it on windows:
- First issue is there a huge difference how `vim.fn.expand("%")` works on windows and unix:
for file `__tests__/file.test.ts` in nvim running command
`:lua =vim.fn.expand("%")` will show
unix: `__tests__/file.test.ts`
windows: `C:/project\__tests__/file.test.ts`

- Second is jest not exactly expecting pattern to be full path the the file. I'm not sure but I assume jest always running pattern search on current directory and providing full path just makes so there is no files matching that pattern ever

    - Also jest seem to expect pattern to be unix style always, no matter the OS it's running on

Solution in the PR is to reduce windows version of path to the same pattern it is for unix. Solution is universal, on unix `vim.fn.substitute` just doesn't do anything since path already lacking `cwd` part

I've tested it on both windows and ubuntu and it seem to work the as intended on both platforms

Help needed with writing tests because `./scripts/test` throws an error for me so I have no idea if I broke something
```sh
Error detected while processing command line:
E492: Not an editor command: PlenaryBustedDirectory tests/ {minimal_init = 'tests/init.vim'}
```

