### PR TITLE
feat: declare jest available if the binary exists in node_modules/.bin

### DIFF
--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -16,10 +16,20 @@ local parameterized_tests = require("neotest-jest.parameterized-tests")
 ---@type neotest.Adapter
 local adapter = { name = "neotest-jest" }
 
+local rootJestBinary = vim.fn.getcwd() .. "/node_modules/.bin/jest"
 local rootPackageJson = vim.fn.getcwd() .. "/package.json"
+
+local function rootProjectHasJestBinary()
+  local success = pcall(lib.files.read, rootJestBinary)
+  return success
+end
 
 ---@return boolean
 local function rootProjectHasJestDependency()
+  if rootProjectHasJestBinary() then
+    return true
+  end
+
   local path = rootPackageJson
 
   local success, packageJsonContent = pcall(lib.files.read, path)


### PR DESCRIPTION
Perhaps a bit controversial, but at my work we have a test utility package which has Jest as a direct dependency. Because of this we do not include Jest as a (dev) dependency in the `package.json` files of our apps/libs. As a result I was unable to use the `neotest-jest` plugin successfully.

I was thinking that actually in order for Jest to run in a project, the only precondition is that the binary is available in `node_modules/.bin/`, so perhaps it makes more sense to check if that's the case instead of reading the `package.json` files.

This has fixed my issue, but perhaps there are some ramifications of this approach which I hadn't considered yet. If so feel free to close this PR.

If this does seem like a good general improvement, then some additional commits might be in order to remove the code that checks the `package.json` files.