### PR TITLE
feat: Optionally require discovering jest dependency locally

### DIFF
--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -122,11 +122,7 @@ function adapter.is_test_file(file_path)
     end
   end
   ::matched_pattern::
-  if require_jest_dependency == true then
-    return is_test_file and hasJestDependency(file_path)
-  else
-    return is_test_file
-  end
+  return is_test_file and (not require_jest_dependency or hasJestDependency(file_path))
 end
 
 function adapter.filter_dir(name)

--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -99,6 +99,7 @@ end
 
 local getJestCommand = jest_util.getJestCommand
 local getJestConfig = jest_util.getJestConfig
+local require_jest_dependency = true
 
 ---@param file_path? string
 ---@return boolean
@@ -121,7 +122,11 @@ function adapter.is_test_file(file_path)
     end
   end
   ::matched_pattern::
-  return is_test_file and hasJestDependency(file_path)
+  if require_jest_dependency == true then
+    return is_test_file and hasJestDependency(file_path)
+  else
+    return is_test_file
+  end
 end
 
 function adapter.filter_dir(name)
@@ -522,6 +527,9 @@ setmetatable(adapter, {
       getStrategyConfig = function()
         return opts.strategy_config
       end
+    end
+    if opts.require_jest_dependency ~= nil then
+      require_jest_dependency = opts.require_jest_dependency
     end
 
     if opts.jest_test_discovery then


### PR DESCRIPTION
#132 

This fix provides the option `require_jest_dependency` - defaulted to true - that allows the plugin to perform the dependency discovery step optionally.