### PR TITLE
feat: add option to skip dependency check

### DIFF
--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -12,6 +12,7 @@ local parameterized_tests = require("neotest-jest.parameterized-tests")
 ---@field env? table<string, string>|fun(): table<string, string>
 ---@field cwd? string|fun(): string
 ---@field strategy_config? table<string, unknown>|fun(): table<string, unknown>
+---@field skipDependencyCheck? boolean
 
 ---@type neotest.Adapter
 local adapter = { name = "neotest-jest" }
@@ -52,6 +53,10 @@ end
 ---@param path string
 ---@return boolean
 local function hasJestDependency(path)
+  if adapter.skipDependencyCheck then
+    return true
+  end
+
   local rootPath = lib.files.match_root_pattern("package.json")(path)
 
   if not rootPath then
@@ -526,6 +531,10 @@ setmetatable(adapter, {
 
     if opts.jest_test_discovery then
       adapter.jest_test_discovery = true
+    end
+
+    if opts.skipDependencyCheck then
+      adapter.skipDependencyCheck = opts.skipDependencyCheck
     end
 
     return adapter


### PR DESCRIPTION
**Problem**
In some projects, frameworks include Jest as part of their own testing package. As a result, Jest is not listed in the project's dependencies or devDependencies in the package.json file. This causes the current dependency check in neotest-jest to fail, as it relies on detecting Jest in the package.json to determine if the project has jest installed.

This pull request introduces a new feature to the `neotest-jest` adapter, allowing users to skip the dependency check for Jest. The most important changes include the addition of a new field to the adapter, modifications to the `hasJestDependency` function, and updates to the adapter initialization to support the new option.

Changes to support skipping dependency check:

* [`lua/neotest-jest/init.lua`](diffhunk://#diff-13047bd2b66848e27a90278d4ec653631a1ccddd605e47f618391276bc47165bR15): Added a new field `skipDependencyCheck` to the adapter's type definition.
* [`lua/neotest-jest/init.lua`](diffhunk://#diff-13047bd2b66848e27a90278d4ec653631a1ccddd605e47f618391276bc47165bR56-R59): Modified the `hasJestDependency` function to return `true` if `skipDependencyCheck` is set.
* [`lua/neotest-jest/init.lua`](diffhunk://#diff-13047bd2b66848e27a90278d4ec653631a1ccddd605e47f618391276bc47165bR536-R539): Updated the adapter initialization to set `skipDependencyCheck` based on the provided options.

**Example Usage**
```lua
require('neotest-jest')({
    skipDependencyCheck = true,
    -- Other options...
})
```