### PR TITLE
fix: test pattern mattching for nearest test execution

### DIFF
--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -393,7 +393,7 @@ function adapter.build_spec(args)
     testNamePattern = pos.is_parameterized
         and parameterized_tests.replaceTestParametersWithRegex(testNamePattern)
       or testNamePattern
-    testNamePattern = "'^" .. testNamePattern
+    testNamePattern = "'" .. testNamePattern
     if pos.type == "test" then
       testNamePattern = testNamePattern .. "$'"
     else


### PR DESCRIPTION
Jest config `testPatternName` matches against the full test name and currently doesn't identify the nearest test if runnng on parametrized context.

An example, the current implementation fails to run TEST1 alone:

```typescript
describe.each([true, false])('is it enabled? [%s]', isEnabled => {

  it('[TEST1] should run this test', () => {
    expect(true).toBeTruthy()
  });

  it('[TEST2] dont run this test', () => {
    throw new Error('I have failed you');
  });
});
```

Full test name in this case would be: 
* `is it enabled? [true] [TEST1] should run this test`
* `is it enabled? [false] [TEST1] should run this test`

Or maybe my configuration is the problem here:
```lua
require("neotest-jest")({
    jestCommand = "yarn test --",
    jestConfigFile = function()
        return vim.fn.getcwd() .. "/jest.config.js"
    end,
    jest_test_discovery = true,
    --env = { CI = true },
    cwd = function()
        return vim.fn.getcwd()
    end,
}),
```