### PR TITLE
Accept `spec` files

### DIFF
--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -114,7 +114,7 @@ function adapter.is_test_file(file_path)
 
   for _, x in ipairs({ "spec", "e2e%-spec", "test", "unit", "regression", "integration" }) do
     for _, ext in ipairs({ "js", "jsx", "coffee", "ts", "tsx" }) do
-      if string.match(file_path, "%." .. x .. "%." .. ext .. "$") then
+      if string.match(file_path, "[./]" .. x .. "%." .. ext .. "$") then
         is_test_file = true
         goto matched_pattern
       end

--- a/spec/spec.ts
+++ b/spec/spec.ts
@@ -1,0 +1,5 @@
+describe('spec file', () => {
+  it('runs', () => {
+    expect(true).toBe(true)
+  })
+})

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -18,6 +18,7 @@ end)
 describe("is_test_file", function()
   it("matches jest files", function()
     assert.True(plugin.is_test_file("./spec/basic.test.ts"))
+    assert.True(plugin.is_test_file("./spec.ts"))
   end)
 
   it("does not match plain js files", function()


### PR DESCRIPTION
Hello 🤗!

It seems the existing logic only accounts for files that follow the pattern of `{name}.{"spec"|"e2e%-spec"|"test"|"unit"|"regression"|"integration"}.{extension}`, which is fine. But sometimes test files are also named as just `spec.{extension}`, which makes the adapter to completely overlook them.

I changed the logic for judging if it's a test file to account for either `{name}.{"spec"|"e2e%-spec"|"test"|"unit"|"regression"|"integration"}.{extension}` or `spec.{extension}` files.