### PR TITLE
Fix for Jest 30 skipped tests

### DIFF
--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -383,7 +383,7 @@ function adapter.build_spec(args)
   end
 
   local pos = args.tree:data()
-  local testNamePattern = "'.*'"
+  local testNamePattern = ".*"
 
   if pos.type == "test" or pos.type == "namespace" then
     -- pos.id in form "path/to/file::Describe text::test text"


### PR DESCRIPTION
Hi, based on the discussions had in issues #135 and #146 , this PR seems to fix things with the neotest test runner. I’ve tested that this works with latest Jest versions from 27 through to 30.