### PR TITLE
Fix dap broken initialization when starting a debug session from a test

### DIFF
--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -7,6 +7,7 @@ local util = require("neotest-jest.util")
 local jest_util = require("neotest-jest.jest-util")
 local parameterized_tests = require("neotest-jest.parameterized-tests")
 local types = require("neotest.types")
+local nio = require("nio")
 
 local ResultStatus = types.ResultStatus
 
@@ -488,6 +489,9 @@ function adapter.build_spec(args)
   -- Creating empty file for streaming results
   lib.files.write(results_path, "")
   local stream_data, stop_stream = util.stream(results_path)
+
+  -- synchronize with main thread to safely load dap
+  nio.scheduler()
 
   return {
     command = command,


### PR DESCRIPTION
I am using LazyVim.

When starting a debug session from a Jest test from inside the neotest summary window, dap will fail to initialize if it wasn't already loaded. If dap was already loaded in the session, debugging the test will work as expected.

After some investigation, the reason is neotest-jest's `adapter.build_spec` is starting a write operation before returning the control to neotest:
https://github.com/nvim-neotest/neotest-jest/blob/a36df9109c75bd1ae46b7bad274615dbbe6e4dcd/lua/neotest-jest/init.lua#L488-L492

This results in neotest requiring dap while in a fast event context, which results in dap failing to initialize.

Here is a recording of a debug session working as expected because dap was loaded beforehand (by adding a breakpoint):

https://github.com/user-attachments/assets/27b6b52d-a294-41a6-b28a-85e18f8a2610

Here is a recording of a debug session failing to initialize because dap hasn't been loaded until neotest requires it:

https://github.com/user-attachments/assets/8816ff55-9b20-442f-b33c-a7ba5b55d12d

This PR solves the issue by forcing a nio synchronization before yielding back to neotest. Result:

https://github.com/user-attachments/assets/44a6dc01-fa47-4e7c-a74e-d29651c13f23

I am wondering though if this synchronization should happen on neotest before requiring dap, freeing every single adapter of potentially hitting this corner case (e.g. I have an identical patch ready for [neotest-vitest](https://github.com/marilari88/neotest-vitest)).

Thoughts?