### PR TITLE
Fix subprocess module loading issue for build_position

### DIFF
--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -283,7 +283,7 @@ function adapter.discover_positions(path)
   local positions = lib.treesitter.parse_positions(path, query, {
     nested_tests = false,
     ---@diagnostic disable-next-line: assign-type-mismatch
-    build_position = 'require("neotest-jest").build_position',
+    build_position = adapter.build_position,
   })
 
   if adapter.jest_test_discovery then


### PR DESCRIPTION
## Problem

When `build_position` is passed as a string `'require("neotest-jest").build_position'` to `lib.treesitter.parse_positions()`, it fails to load in subprocess context. This causes several issues:

- Test discovery fails with `module 'neotest-jest' not found` errors
- Users see "No tests found" even when tests exist

This issue was reported in #165.

## Root Cause

Neotest uses subprocesses for parsing test positions for performance. When a string is passed as `build_position`, neotest tries to `loadstring()` and execute it in the subprocess. However, in the subprocess context, `require("neotest-jest")` fails because the module isn't properly loaded in that isolated environment.

From the neotest source code:
```lua
if type(opts.build_position) == "string" then
  local loaded, err = loadstring("return " .. opts.build_position)
  assert(loaded, ("Couldn't parse \`build_position\` option: %s"):format(err))
  opts.build_position = loaded()
end
```

The subprocess tries to execute `require("neotest-jest").build_position` but the module context doesn't exist there.

## Solution

This PR changes line 286 from:
```lua
build_position = 'require("neotest-jest").build_position',
```

To:
```lua
build_position = adapter.build_position,
```

By passing the function directly instead of a string reference, neotest automatically disables subprocess mode for this adapter (as documented in neotest's code):

```lua
if type(opts.build_position) == "function" or type(opts.position_id) == "function" then
  logger.warn(
    "Using \`build_position\` or \`position_id\` functions with subprocess parsing is not supported, switch to using strings for remote calls"
  )
  return neotest.lib.treesitter._parse_positions(file_path, query, opts)
end
```

This fallback to non-subprocess parsing avoids all module loading issues while maintaining functionality.

## Trade-offs

- **Pro**: Fixes test discovery for all users experiencing the issue
- **Pro**: Simple one-line change
- **Con**: Disables subprocess mode for parsing, which may have a minor performance impact on very large codebases
- **Note**: The performance impact should be negligible for most projects, and correctness is more important than the minor optimization

## Testing

Tested with:
- Jest projects with standard test file patterns (`.test.ts`, `.spec.js`)
- Projects with custom test directory structures
- Verified that tests are now discovered and run correctly
- Confirmed test statuses (passed/failed) are reported accurately

Fixes #165