### PR TITLE
Fix deprecated table flattern

### DIFF
--- a/lua/neotest-jest/util.lua
+++ b/lua/neotest-jest/util.lua
@@ -158,7 +158,7 @@ function M.search_ancestors(startpath, func)
 end
 
 function M.root_pattern(...)
-  local patterns = compat.tbl_flatten({ ... })
+  local patterns = vim.iter({ ... }):flatten():totable()
   local function matcher(path)
     for _, pattern in ipairs(patterns) do
       for _, p in ipairs(vim.fn.glob(M.path.join(path, pattern), true, true)) do


### PR DESCRIPTION
Fixes this warning:

```
- ⚠️ WARNING vim.tbl_flatten is deprecated. Feature will be removed in Nvim 0.13
  - ADVICE:
    - use vim.iter(…):flatten():totable() instead.
    - stack traceback:
        /Users/luther/.local/share/nvim/site/pack/core/opt/neotest-jest/lua/neotest-jest/util.lua:161
        /Users/luther/.local/share/nvim/site/pack/core/opt/neotest-jest/lua/neotest-jest/jest-util.lua:8
        =[C]:-1
        /Users/luther/.local/share/nvim/site/pack/core/opt/neotest-jest/lua/neotest-jest/init.lua:7
        =[C]:-1
        /Users/luther/.config/nvim/init.lua:474
```